### PR TITLE
If only new content is added optionally treat test as successful

### DIFF
--- a/btest-diff
+++ b/btest-diff
@@ -12,6 +12,7 @@
 #   TEST_DIFF_CANONIFIER
 #   TEST_DIFF_BRIEF
 #   TEST_DIFF_FILE_MAX_LINES
+#   TEST_DIFF_IGNORE_ADDED_LINES
 
 # Maximum number of lines to show from mismatching input file by default.
 MAX_LINES=100
@@ -94,7 +95,15 @@ if [ -e $TEST_BASELINE/$canon ]; then
 
    if [ $error -eq 0 ]; then
        echo "== Diff ===============================" >>$TEST_DIAGNOSTICS
-       diff -au $@ $diff1 $diff2 >>$TEST_DIAGNOSTICS
+       if [ -n $TEST_DIFF_IGNORE_ADDED_LINES ]; then
+           diff -au $@ $diff1 $diff2 | awk 'BEGIN { p = 0 ; m = 0}
+	/^\- / {m++}
+	/^\+ / {p++}
+	END { if(p>0) {printf("btest-diff: detected lines in output missing from baseline!\n"); }
+	      if(m>0) { exit(1) } else { exit(0) } }' >>$TEST_DIAGNOSTICS
+       else
+           diff -au $@ $diff1 $diff2 >>$TEST_DIAGNOSTICS
+       fi
        result=$?
    fi
 else


### PR DESCRIPTION
This is just an idea I wanted to propose, and thought it is easier to just start with a PR. The thought here is that sometimes it may not matter if additions are made, but it does matter if something that was there is no longer there. It would be nice to have the option of saying: _if this is an addition to Baseline, ignore it and consider test a success, otherwise fail_. This approach can make some tests less prone to apparently failing as a result of a new feature, or some minor modification that adds something to output, which otherwise is effectively inconsequential. This also would be useful in cases where some ambiguity exists, like some contents are `grep`(ed) out of a log, or output, and while you know to expect certain results, there may be something else that only sometimes gets picked up, because of noise in the results being `grep`(ed), or unpredictable nature of logs, etc.

This PR lacks any documentation, etc., which I will happily complete if this will be seen as an acceptable addition.