### PR TITLE
Fixes for the --retries options

### DIFF
--- a/btest
+++ b/btest
@@ -365,9 +365,9 @@ class TestManager(multiprocessing.managers.SyncManager):
             if Options.update_times:
                 self.saveTiming(all_tests)
 
-    def rerun (self, test):
+    def rerun(self, test):
         test.reruns += 1
-        self._tests += [test.clone()]
+        self._tests += [test.clone(increment=False)]
 
     def nextTests(self, thread_num):
         with self._lock:
@@ -515,7 +515,7 @@ class TestManager(multiprocessing.managers.SyncManager):
                     self._failed_expected.value -= 1
 
                 self._unstable.value += 1
-                msg += " on retry, unstable"
+                msg += " on retry #{0}, unstable".format(test.reruns)
                 self._output_handler.testUnstable(test,msg)
 
             self._output_handler.testFinished(test, msg)
@@ -526,7 +526,7 @@ class TestManager(multiprocessing.managers.SyncManager):
         msg = "failed"
 
         if test.reruns > 0:
-            msg += " on retry"
+            msg += " on retry #{0}".format(test.reruns)
 
         if test.known_failure:
             msg += " (expected)"
@@ -774,11 +774,16 @@ class Test(object):
 
     # Copies all control information over to a new Test but replacing the test's
     # content with a new one.
-    def clone(self, content=None):
+    def clone(self, content=None, increment=True):
         clone = Test("")
-        clone.number = self.number + 1
+        clone.number = self.number
         clone.basename = self.basename
-        clone.name = "%s-%d" % (self.basename, clone.number)
+        clone.name = self.basename
+
+        if increment:
+            clone.number = self.number + 1
+            clone.name = "%s-%d" % (self.basename, clone.number)
+
         clone.reruns = self.reruns
         clone.serialize = self.serialize
         clone.ports = self.ports

--- a/btest
+++ b/btest
@@ -799,6 +799,7 @@ class Test(object):
         else:
             clone.contents = self.contents
 
+        clone.files = self.files
         self.cloned = True
 
         return clone

--- a/testing/Baseline/tests.unstable/output
+++ b/testing/Baseline/tests.unstable/output
@@ -1,5 +1,5 @@
 test1 ... failed
-test1-2 ... failed on retry
-test1-3 ... failed on retry
-test1-4 ... ok on retry, unstable
+test1 ... failed on retry #1
+test1 ... failed on retry #2
+test1 ... ok on retry #3, unstable
 0 tests successful, 1 unstable

--- a/testing/tests/unstable.test
+++ b/testing/tests/unstable.test
@@ -1,21 +1,15 @@
 # %TEST-EXEC: btest -z 4 test1 >output 2>&1
 # %TEST-EXEC: btest-diff output
 
-%TEST-START-FILE Baseline/test1-4/output
-0
-1
-2
-3
+%TEST-START-FILE Baseline/test1/output
+ran
+ran
+ran
+ran
 %TEST-END-FILE
 
-%TEST-START-FILE do.sh
-export X=0
-echo $X
-%TEST-END-FILE 
-
 %TEST-START-FILE test1
-@TEST-EXEC: . ../../do.sh >output
-@TEST-EXEC: echo 'export X=$((X+1))' >> ../../do.sh
-@TEST-EXEC: echo 'echo $X' >> ../../do.sh
+@TEST-EXEC: echo ran >> ../../persist
+@TEST-EXEC: cat ../../persist > output
 @TEST-EXEC: btest-diff output
 %TEST-END-FILE

--- a/testing/tests/unstable.test
+++ b/testing/tests/unstable.test
@@ -3,13 +3,26 @@
 
 %TEST-START-FILE Baseline/test1/output
 ran
+more
 ran
+more
 ran
+more
 ran
+more
 %TEST-END-FILE
 
 %TEST-START-FILE test1
-@TEST-EXEC: echo ran >> ../../persist
+@TEST-START-FILE single-output1
+ran
+@TEST-END-FILE
+
+@TEST-START-FILE single-output2
+more
+@TEST-END-FILE
+
+@TEST-EXEC: cat single-output1 >> ../../persist
+@TEST-EXEC: cat single-output2 >> ../../persist
 @TEST-EXEC: cat ../../persist > output
 @TEST-EXEC: btest-diff output
 %TEST-END-FILE


### PR DESCRIPTION
I may have missed something, but `--retries` generally didn't seem usable with `btest-diff` due to how it previously incremented the test names.  Example failure and retry output:

```
 99%] supervisor.config-cluster ... failed
  % 'btest-diff zeek/proxy-1/stdout' failed unexpectedly (exit code 1)
  % cat .diag
  == File ===============================
  == Diff ===============================
  --- /tmp/test-diff.20754.zeek.proxy-1.stdout.baseline.tmp	2020-02-04 04:55:59.031702010 +0000
  +++ /tmp/test-diff.20754.zeek.proxy-1.stdout.tmp	2020-02-04 04:55:59.031702010 +0000
  @@ -1,2 +0,0 @@
  -supervised node zeek_init(), proxy-1, Cluster::PROXY
  -supervised node zeek_done(), proxy-1, proxy-1
  =======================================
  % cat .stderr
  <<< [18371] zeek -j -b /zeek/testing/btest/.tmp/supervisor.config-cluster/config-cluster.zeek
  received termination signal
  >>>
[100%] supervisor.config-cluster-2 ... failed on retry
  % 'btest-diff zeek/supervisor.out' failed unexpectedly (exit code 100)
  % cat .diag
  == File ===============================
  supervisor zeek_init()
  shutting down
  supervisor zeek_done()
  == Error ==============================
  test-diff: no baseline found.
  =======================================
  % cat .stderr
  <<< [20795] zeek -j -b /zeek/testing/btest/.tmp/supervisor.config-cluster-2/config-cluster.zeek
  received termination signal
  >>>
```

The baseline does exist, but not for the `-2` version of the test and it would be crazy to have to create all `-N` baselines for all tests just to use `--retries`, so I removed the name-incrementing.

It also wasn't working for tests which use `@TEST-START-FILE`