### PR TITLE
Add support for emitting Chrome tracing logs

### DIFF
--- a/README
+++ b/README
@@ -288,6 +288,12 @@ and 1 otherwise.
         the timing measurements are recorded as the new baseline instead
         of being compared to a previous baseline.
 
+    --trace-file=TRACEFILE
+        Record test execution timings in Chrome tracing format to the given
+        file. If the file exists already, it is overwritten. The file can be
+        loaded in Chrome-based browsers at `<about:tracing>`_, or converted to
+        standalone HTML with `trace2html <https://pypi.org/project/trace2html/>`_.
+
     -U, --update-baseline
         Records a new baseline for all ``btest-diff`` commands found
         in any of the specified tests. To do this, all tests are run

--- a/btest
+++ b/btest
@@ -1311,14 +1311,18 @@ class Forwarder(OutputHandler):
         for h in self._handlers:
             h.testFailed(test, msg)
 
+    def testSkipped(self, test, msg):
+        for h in self._handlers:
+            h.testSkipped(test, msg)
+
+    def testFinished(self, test, msg):
+        for h in self._handlers:
+            h.testFinished(test, msg)
+
     def testUnstable(self, test, msg):
         """Called when a test failed initially but succeeded in a retry."""
         for h in self._handlers:
             h.testUnstable(test, msg)
-
-    def testSkipped(self, test, msg):
-        for h in self._handlers:
-            h.testSkipped(test, msg)
 
     def replayOutput(self, test):
         for h in self._handlers:

--- a/btest
+++ b/btest
@@ -15,6 +15,7 @@ import tempfile
 import subprocess
 import copy
 import glob
+import json
 import fnmatch
 import time
 import multiprocessing
@@ -1819,6 +1820,34 @@ class XMLReport(OutputHandler):
         print(doc.toprettyxml(indent="    "), file=self._file)
         self._file.close()
 
+class ChromeTracing(OutputHandler):
+    """Output in Chrome tracing format.
+
+    Output files can be loaded into Chrome browser under about:tracing, or
+    converted to standalone HTML files with `trace2html`.
+    """
+    def __init__(self, options, tracefile):
+        OutputHandler.__init__(self, options)
+        self._file = tracefile
+
+    def prepare(self, mgr):
+        self._results = mgr.list([])
+
+    def testFinished(self, test, _):
+        self._results.append({
+                "name": test.name,
+                "ts": test.start * 1e6,
+                "tid": multiprocessing.current_process().pid,
+                "pid": 1,
+                "ph": "X",
+                "cat": "test",
+                "dur": (time.time() - test.start) * 1e6,
+        })
+
+    def finished(self):
+        print(json.dumps(list(self._results)), file=self._file)
+        self._file.close()
+
 ### Timing measurements.
 
 # Base class for all timers.
@@ -2178,6 +2207,8 @@ optparser.add_option("-A", "--show-all", action="store_true", default=False,
                      help="For console output, show one-liners for passing/skipped tests in addition to any failing ones")
 optparser.add_option("-z", "--retries", action="store", dest="retries", type="int", default=0,
                      help="Retry failed tests this many times to determine if they are unstable")
+optparser.add_option("--trace-file", action="store", dest="tracefile", default="",
+                     help="write Chrome tracing file to file; if file exists, it is overwritten")
 
 optparser.set_defaults(mode="TEST")
 (Options, args) = optparser.parse_args()
@@ -2280,6 +2311,14 @@ if Options.xmlfile:
 
     except IOError as e:
         print("cannot open %s: %s" % (Options.xmlfile, e), file=sys.stderr)
+
+if Options.tracefile:
+    try:
+        tracefile = open(Options.tracefile, "w", 1)
+        output_handlers += [ChromeTracing(Options, tracefile)]
+
+    except IOError as e:
+        print("cannot open %s: %s" % (Options.tracefile, e), file=sys.stderr)
 
 output_handler = Forwarder(Options, output_handlers)
 

--- a/btest
+++ b/btest
@@ -1465,7 +1465,7 @@ class CompactConsole(Console):
         msg = " " + self.DarkGray + "(%s)" % msg + self.Normal
         self._consoleAugment(test, msg)
 
-    def testFinished(self, test):
+    def testFinished(self, test, msg):
         test.console_last_line = None
 
     def finished(self):

--- a/testing/Baseline/tests.tracing/output
+++ b/testing/Baseline/tests.tracing/output
@@ -1,0 +1,2 @@
+3
+['cat', 'dur', 'name', 'ph', 'pid', 'tid', 'ts']

--- a/testing/tests/tracing.test
+++ b/testing/tests/tracing.test
@@ -1,0 +1,15 @@
+# %TEST-EXEC-FAIL: btest -d --trace-file=trace.json t1 t2 t3
+# %TEST-EXEC: cat trace.json | python -c 'import json, sys; xs = json.load(sys.stdin); print(len(xs)); print(sorted([str(x) for x in xs[0].keys()]))' > output
+# %TEST-EXEC: btest-diff output
+
+%TEST-START-FILE t1
+@TEST-EXEC: exit 0
+%TEST-END-FILE
+
+%TEST-START-FILE t2
+@TEST-EXEC: exit 1
+%TEST-END-FILE
+
+%TEST-START-FILE t3
+@TEST-EXEC: exit 0
+%TEST-END-FILE


### PR DESCRIPTION
This patch add support for Chrome tracing logs. Logs can be converted to standalone HTML with e.g., `trace2html`. While this tool is primarily intended to profile Chrome itself, it is also an easy way to visualize e.g., the timing and scheduling of parallel processes, useful to identify BTests which contribute most to test execution wall time.

Below a rather uneventful example trace displayed in Firefox after processing with `trace2html`.
<img width="1639" alt="Screen Shot 2020-04-27 at 11 08 40 PM" src="https://user-images.githubusercontent.com/324957/80421589-01594900-88dd-11ea-86e7-09f1b1afe9e0.png">
