### PR TITLE
Terminate worker processes on keyboard interrupt.

### DIFF
--- a/btest
+++ b/btest
@@ -313,13 +313,21 @@ class TestManager(multiprocessing.managers.SyncManager):
         if num_threads:
             threads = []
 
-            for i in range(num_threads):
-                t = multiprocessing.Process(name="#%d" % (i+1), target=lambda: self.threadRun(i))
-                t.start()
-                threads += [t]
+            try:
+                for i in range(num_threads):
+                    t = multiprocessing.Process(
+                            name="#%d" % (i+1),
+                            target=lambda: self.threadRun(i))
+                    t.start()
+                    threads += [t]
 
-            for t in threads:
-                t.join()
+                for t in threads:
+                    t.join()
+
+            except KeyboardInterrupt:
+                for t in threads:
+                    t.terminate()
+                    t.join()
 
         else:
             # No threads, just run all directly.


### PR DESCRIPTION
Explicitly terminating the worker processes before cleaning up main
process prevents the workers from dying with a broken pipes to the
parent when trying to send back test results.