### PR TITLE
Fix %DIR not being set correctly in cloned tests

### DIFF
--- a/btest
+++ b/btest
@@ -807,6 +807,7 @@ class Test(object):
             clone.contents = self.contents
 
         clone.files = self.files
+        clone.dir = self.dir
         self.cloned = True
 
         return clone

--- a/testing/Baseline/tests.start-next-dir/output
+++ b/testing/Baseline/tests.start-next-dir/output
@@ -1,0 +1,3 @@
+tests.start-next-dir/mydir
+tests.start-next-dir/mydir
+tests.start-next-dir/mydir

--- a/testing/Baseline/tests.unstable-dir/output
+++ b/testing/Baseline/tests.unstable-dir/output
@@ -1,0 +1,5 @@
+mydir.test1 ... failed
+mydir.test1 ... failed on retry #1
+mydir.test1 ... failed on retry #2
+mydir.test1 ... ok on retry #3, unstable
+0 tests successful, 1 unstable

--- a/testing/tests/start-next-dir.test
+++ b/testing/tests/start-next-dir.test
@@ -1,0 +1,8 @@
+# %TEST-EXEC: btest mydir/mytest
+# %TEST-EXEC: btest-diff output
+
+%TEST-START-FILE mydir/mytest
+@TEST-EXEC: echo $(basename $(dirname %DIR))/$(basename %DIR) >>../../output
+@TEST-START-NEXT
+@TEST-START-NEXT
+%TEST-END-FILE

--- a/testing/tests/unstable-dir.test
+++ b/testing/tests/unstable-dir.test
@@ -1,0 +1,38 @@
+# %TEST-EXEC: btest -t -z 4 mydir/test1 >output 2>&1
+# %TEST-EXEC: btest-diff output
+
+%TEST-START-FILE Baseline/mydir.test1/test1-output
+ran
+more
+ran
+more
+ran
+more
+ran
+more
+%TEST-END-FILE
+
+%TEST-START-FILE Baseline/mydir.test1/test1-dir-output
+tests.unstable-dir/mydir
+tests.unstable-dir/mydir
+tests.unstable-dir/mydir
+tests.unstable-dir/mydir
+%TEST-END-FILE
+
+%TEST-START-FILE mydir/test1
+@TEST-START-FILE single-output1
+ran
+@TEST-END-FILE
+
+@TEST-START-FILE single-output2
+more
+@TEST-END-FILE
+
+@TEST-EXEC: echo $(basename $(dirname %DIR))/$(basename %DIR) >> ../../persist-dirs
+@TEST-EXEC: cat single-output1 >> ../../persist
+@TEST-EXEC: cat single-output2 >> ../../persist
+@TEST-EXEC: cat ../../persist > test1-output
+@TEST-EXEC: cat ../../persist-dirs > test1-dir-output
+@TEST-EXEC: btest-diff test1-output
+@TEST-EXEC: btest-diff test1-dir-output
+%TEST-END-FILE


### PR DESCRIPTION
Both the `TEST-START-NEXT` and `btest --retries` functionality rely
on the mechanism of cloning `Test` objects, except the `clone()` method
did not copy the member on which `%DIR` is based, resulting in
inconsistent `%DIR` value across test runs.

Example from Zeek showing how `%DIR` is not set consistently across retries: https://cirrus-ci.com/task/6192299975639040

Fixes #11