### PR TITLE
Add new options -F/--abort-on-failure that will abort once at least o…

### DIFF
--- a/btest
+++ b/btest
@@ -2555,7 +2555,8 @@ try:
 
 except Abort as e:
     output_handler.finished()
-    print(e.message, file=sys.stderr)
+    print(e, file=sys.stderr)
+    sys.stderr.flush()
     os._exit(1)
 
 except (KeyboardInterrupt, IOError): # Ctrl-C can lead to broken pipe.


### PR DESCRIPTION
…ne test has failed.

In parallel mode, we still let all currently executing tests run to
completion because it's tricky to kill them immediately. Might be
something for the future to address, probably by first getting rid of
non-threaded mode altogether to unify the logic.

Closes #29.