### PR TITLE
Support BTest installation via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+project(btest)
+
+# Install scripts
+install(DIRECTORY DESTINATION bin)
+install(PROGRAMS
+    btest
+    btest-ask-update
+    btest-bg-run
+    btest-bg-run-helper
+    btest-bg-wait
+    btest-diff
+    btest-setsid
+    btest-progress
+    sphinx/btest-diff-rst
+    sphinx/btest-rst-cmd
+    sphinx/btest-rst-include
+    sphinx/btest-rst-pipe
+    DESTINATION bin)
+
+if ( NOT PY_MOD_INSTALL_DIR )
+    # This is not a Zeek-bundled install, from which we'd inherit that
+    # variable.  Default to "home"-style install.
+    set(PY_MOD_INSTALL_DIR lib/python)
+endif ()
+
+# Install the Python module
+install(DIRECTORY DESTINATION ${PY_MOD_INSTALL_DIR})
+install(FILES sphinx/btest-sphinx.py DESTINATION ${PY_MOD_INSTALL_DIR})
+
+message(
+    "\n====================|  BTest Build Summary  |==================="
+    "\n"
+    "\nInstall prefix:      ${CMAKE_INSTALL_PREFIX}"
+    "\nPython module path:  ${PY_MOD_INSTALL_DIR}"
+    "\n"
+    "\n================================================================\n"
+)

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@
 
 from distutils.core import setup, Extension
 
+# When making changes to the following list, remember to keep
+# CMakeLists.txt in sync.
 scripts = [
     "btest",
     "btest-ask-update",


### PR DESCRIPTION
This adds a CMakeList.txt that causes btest to be installed via CMake when bundled with Zeek. Since btest has a lot more scripts than zkg (where our CMake approach basically directly installs zkg and its module) I didn't want to list all of the scripts in the CMakeLists.txt. I instead tried a few ways of relying on a Python invocation of `setup.py`, since that approach means you can ignore the CMake side of things in the future. I tried two variants:

* Copy the whole source tree into the build directory, and allow `setup.py` to create any intermediate directories it requires, while controlling the scripts and module contents as needed via command-line options. This is relatively straightforward and creation of local `build` or `dist` directories is no problem.
* Run `setup.py` from the source directory, but ensure that it creates any intermediate directories (such as `build`) in the CMake build directory. This also works but it's more complex — you need to explicitly invoke `setup.py build` with a bunch of flags that control scripts and module, and then run it again so it installs based on those intermediate build directories.

In the end I found the former approach more straightforward, so that's what I went for. There's a small hiccup around the copying of the source tree: when your CMake build directory resides in the source tree (as it intutively would be with the usual `mkdir build && cd build && cmake ..` routine), CMake isn't smart enough to notice the recursive copying and blows up after a while. I addressed this by explicitly skipping the build directory, if contained in the source tree. This doesn't matter for the Zeek-bundled installation, where this constellation doesn't come up.

If we're okay with this approach, we could eventually use the same in zkg.

I've verified that the bundled btest installation works, and that a Zeek package installation via zkg works correctly (including test cases) even when the Zeek installation directory (with zeek, zkg, btest) isn't in PATH.

Resolves zeek/zeek#1360, companion PR to zeek/zeek#1366. 