### PR TITLE
Fix a missing return value in `get_env_from_alternative()`

### DIFF
--- a/btest
+++ b/btest
@@ -2311,7 +2311,7 @@ if Options.alternatives:
     # If multiple alternatives set it, we pick the value from the first.
     def get_env_from_alternative(env, opt, default, transform=None):
         if env in os.environ:
-            return
+            return default
 
         for tag in Options.alternatives:
             value = getOption(env, None, section="environment-%s" % tag)

--- a/btest
+++ b/btest
@@ -2454,7 +2454,6 @@ RE_START_FILE = re.compile(CommandPrefix + "START-FILE +([^\r\n ]*)")
 RE_END_FILE = re.compile(CommandPrefix + "END-FILE")
 
 # Commands as tuple (tag, regexp, more-than-one-is-ok, optional, group-main, group-add)
-# pylint: disable=bad-whitespace
 RE_EXEC                = ("exec",            re.compile(CommandPrefix + "EXEC(-FAIL)?: *(.*)"), True, False, 2, 1)
 RE_REQUIRES            = ("requires",        re.compile(CommandPrefix + "REQUIRES: *(.*)"), True, True, 1, -1)
 RE_GROUP               = ("group",           re.compile(CommandPrefix + "GROUP: *(.*)"), True, True, 1, -1)
@@ -2466,7 +2465,6 @@ RE_COPY_FILE           = ("copy-file",       re.compile(CommandPrefix + "COPY-FI
 RE_KNOWN_FAILURE       = ("known-failure",   re.compile(CommandPrefix + "KNOWN-FAILURE"), False, True, -1, -1)
 RE_MEASURE_TIME        = ("measure-time",    re.compile(CommandPrefix + "MEASURE-TIME"), False, True, -1, -1)
 RE_DOC                 = ("doc",             re.compile(CommandPrefix + "DOC: *(.*)"), True, True, 1, -1)
-# pylint: enable=bad-whitespace
 
 Commands = (RE_EXEC, RE_REQUIRES, RE_GROUP, RE_SERIALIZE, RE_PORT, RE_INCLUDE_ALTERNATIVE, RE_IGNORE_ALTERNATIVE, RE_COPY_FILE, RE_KNOWN_FAILURE, RE_MEASURE_TIME, RE_DOC)
 

--- a/testing/tests/alternatives-testbase.test
+++ b/testing/tests/alternatives-testbase.test
@@ -1,2 +1,11 @@
 # %TEST-EXEC: cp -r ../../Files/local_alternative .
 # %TEST-EXEC: btest -a local tests/local-alternative-found.test
+
+# Verify that a BTEST_TEST_BASE environment value overrides any such
+# variable set in an alternatives section. If the environment
+# variable were ignored, the following setup would pick the
+# x/y/local_alternative folder, which doesn't exist.
+# %TEST-EXEC: mkdir -p x/y
+# %TEST-EXEC: cp -r ../../Files/local_alternative x/y/another_alternative
+# %TEST-EXEC: cd x/y/another_alternative/tests && mv local-alternative-found.test another-alternative-found.test
+# %TEST-EXEC: BTEST_TEST_BASE=x/y/another_alternative btest -a local tests/another-alternative-found.test


### PR DESCRIPTION
When the environment defines `BTEST_TEST_BASE`, `get_env_from_alternative()` didn't return a value. I suspect this was a leftover from the earlier iteration of that code, which only ran if the variable in question wasn't in the environment.

Seems the alternative to returning `default` would be to grab the found value from the environment and apply the transformation to it ... I'm not sure what's better here.

I'm adding a test case that has an alternative section spelling out a `BTEST_TEST_BASE`, but gets overridden by the environment.

Reported by @j0ej0h.