### PR TITLE
Add LGTM config.

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,6 @@
+extraction:
+  python:
+    index:
+      include:
+        - btest
+        - btest-setsid


### PR DESCRIPTION
Previosly LGTM was not detecting all Python source files, most notable
`btest`. This patch adds a dedicated configuration so more Python source
files are analyzed.