### PR TITLE
Improve backtick command execution with spaces

### DIFF
--- a/README
+++ b/README
@@ -27,9 +27,11 @@ Prerequisites
 
 BTest has the following prerequisites:
 
-- Python version >= 3.5 (older version may work, but are not well-tested).
+- Python version >= 3.5 (older versions may work, but are not
+  well-tested).
 
-- Bash (note that on FreeBSD, bash is not installed by default).
+- Bash (note that on FreeBSD and Alpine Linux, bash is not installed
+  by default).
 
 BTest has the following optional prerequisites to enable additional
 functionality:

--- a/btest
+++ b/btest
@@ -161,7 +161,7 @@ def ExpandBackticks(origvalue):
             return ""
 
         try:
-            pp = subprocess.Popen(cmd.split(), stdout=subprocess.PIPE)
+            pp = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
         except OSError as e:
             error("cannot execute '%s': %s" % (cmd, e))
 

--- a/testing/btest.tests.cfg
+++ b/testing/btest.tests.cfg
@@ -13,7 +13,7 @@ ORIGPATH=%(default_path)s
 ENV1=Foo
 ENV2=%(testbase)s
 ENV3=`expr 42`
-ENV4=`echo (%(testbase)s=%(testbase)s)`
+ENV4=`echo \(%(testbase)s=%(testbase)s\)`
 
 [environment-foo]
 FOO=BAR


### PR DESCRIPTION
### Warning: breaking change

If anyone depends on the previous implementation to do anything remotely complex with backtick expansion, it is likely to break. I would argue, however, that doing anything remotely complex with the previous implementation can be quite challenging to impossible (I had to do what I needed in a one-line shell script). The new implementation aligns much better with the mental model of backticks that people are familiar with in the shell.

Instead of naive splitting of the command string into arguments with Python's str.split(), pass the command string as-is as the string arg to subprocess.Popen() and let the shell parse it. I was trying to do something like this, and it was pretty much impossible in the previous implementation without moving this code into a one-line shell script and calling that script:

```
RPEO_BASE=`dirname $(git rev-parse --absolute-git-dir)`
```

Note that I had to escape the parens in testing/btest.tests.cfg ENV4 otherwise the shell would try to execute what was inside in a sub-shell.

Also made some minor README tweaks.