### PR TITLE
Remove dependency on distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from distutils.core import setup, Extension
+from setuptools import setup
 
 # When making changes to the following list, remember to keep
 # CMakeLists.txt in sync.


### PR DESCRIPTION
The distutils module will be removed from Python in 3.12[1].

[1] https://github.com/python/cpython/commit/0faa0ba240e815614e5a2900e48007acac41b214
