### PR TITLE
Always use UTF-8 encoding for BTest input and output files.

### DIFF
--- a/btest
+++ b/btest
@@ -103,10 +103,7 @@ def platform():
 
 
 def getDefaultBtestEncoding():
-    if locale.getlocale() is None:
-        return 'utf-8'
-
-    return locale.getpreferredencoding()
+    return 'UTF-8'
 
 
 def validate_version_requirement(required: str, present: str):
@@ -382,7 +379,7 @@ class TestManager(multiprocessing.managers.SyncManager):
         # Record failed tests if not updating.
         if Options.mode != "UPDATE" and Options.mode != "UPDATE_INTERACTIVE":
             try:
-                state = open(StateFile, "w")
+                state = open(StateFile, "w", encoding=getDefaultBtestEncoding())
             except IOError:
                 error("cannot open state file %s" % StateFile)
 
@@ -1010,9 +1007,13 @@ class Test(object):
 
             out.close()
 
-        self.log = open(os.path.join(self.tmpdir, ".log"), "w")
-        self.stdout = open(os.path.join(self.tmpdir, ".stdout"), "w")
-        self.stderr = open(os.path.join(self.tmpdir, ".stderr"), "w")
+        self.log = open(os.path.join(self.tmpdir, ".log"), "w", encoding=getDefaultBtestEncoding())
+        self.stdout = open(os.path.join(self.tmpdir, ".stdout"),
+                           "w",
+                           encoding=getDefaultBtestEncoding())
+        self.stderr = open(os.path.join(self.tmpdir, ".stderr"),
+                           "w",
+                           encoding=getDefaultBtestEncoding())
 
         for cmd in self.requires:
             (success, rc) = self.execute(cmd, apply_alternative=self.alternative)
@@ -2558,7 +2559,7 @@ defaults["baselinedir"] = os.path.abspath(
 
 # Parse our config
 Config = getcfgparser(defaults)
-Config.read(Options.config)
+Config.read(Options.config, encoding=getDefaultBtestEncoding())
 
 defaults["baselinedir"] = getOption("BaselineDir", defaults["baselinedir"])
 

--- a/btest
+++ b/btest
@@ -102,10 +102,6 @@ def platform():
     return pform.system()
 
 
-def getDefaultBtestEncoding():
-    return 'UTF-8'
-
-
 def validate_version_requirement(required: str, present: str):
     '''Helper function to validate that a `present` version is semantically newer or equal than a `required` version.'''
     def extract_version(v: str):
@@ -379,7 +375,7 @@ class TestManager(multiprocessing.managers.SyncManager):
         # Record failed tests if not updating.
         if Options.mode != "UPDATE" and Options.mode != "UPDATE_INTERACTIVE":
             try:
-                state = open(StateFile, "w", encoding=getDefaultBtestEncoding())
+                state = open(StateFile, "w", encoding="utf-8")
             except IOError:
                 error("cannot open state file %s" % StateFile)
 
@@ -997,7 +993,7 @@ class Test(object):
 
         for (file, content) in self.contents:
             localfile = os.path.join(self.tmpdir, os.path.basename(file))
-            out = io.open(localfile, "w", encoding=getDefaultBtestEncoding())
+            out = io.open(localfile, "w", encoding="utf-8")
 
             try:
                 for line in content:
@@ -1007,13 +1003,9 @@ class Test(object):
 
             out.close()
 
-        self.log = open(os.path.join(self.tmpdir, ".log"), "w", encoding=getDefaultBtestEncoding())
-        self.stdout = open(os.path.join(self.tmpdir, ".stdout"),
-                           "w",
-                           encoding=getDefaultBtestEncoding())
-        self.stderr = open(os.path.join(self.tmpdir, ".stderr"),
-                           "w",
-                           encoding=getDefaultBtestEncoding())
+        self.log = open(os.path.join(self.tmpdir, ".log"), "w", encoding="utf-8")
+        self.stdout = open(os.path.join(self.tmpdir, ".stdout"), "w", encoding="utf-8")
+        self.stderr = open(os.path.join(self.tmpdir, ".stderr"), "w", encoding="utf-8")
 
         for cmd in self.requires:
             (success, rc) = self.execute(cmd, apply_alternative=self.alternative)
@@ -2214,7 +2206,7 @@ def readTestFile(filename):
         return []
 
     try:
-        input = io.open(filename, encoding=getDefaultBtestEncoding(), newline='')
+        input = io.open(filename, encoding="utf-8", newline='')
     except IOError as e:
         error("cannot read test file: %s" % e)
 
@@ -2559,7 +2551,7 @@ defaults["baselinedir"] = os.path.abspath(
 
 # Parse our config
 Config = getcfgparser(defaults)
-Config.read(Options.config, encoding=getDefaultBtestEncoding())
+Config.read(Options.config, encoding="utf-8")
 
 defaults["baselinedir"] = getOption("BaselineDir", defaults["baselinedir"])
 


### PR DESCRIPTION
We previously would use the system locale to determine what encoding to expect for BTest input files, either implicitly by not specifying an encoding, or explicitly by querying the current locale. To make matters worse, we recently migrated from `locale.getdefaultlocale` to `locale.getlocale` which behaves differently, mainly since `getdefaultlocale` behaved surprisingly was reason for it becoming deprecated with 3.11, see https://docs.python.org/3/library/locale.html; our change here essentially caused a regression if e.g., a `btest.cfg` contained environment variables modifying the locale.

This can now cause BTest to behave differently depending on whether environment variables like `LC_ALL` or similar are set, even when the intention was to only specify what locale to use for the programs under test.

With this patch we always use UTF-8 for BTest input and output files to make its behavior more deterministic. Uses of an implicit encoding where identified by running `python3 -X warn_default_encoding btest ...`. This adjusted behavior seems to capture what we and probably also users already seem to have expected.