### PR TITLE
Do not ignore case of options.

### DIFF
--- a/btest
+++ b/btest
@@ -269,7 +269,17 @@ def runSubprocess(*args, **kwargs):
 
 def getcfgparser(defaults):
     configparser.ConfigParser.itemsNoDefaults = cpItemsNoDefaults
-    cfg = configparser.ConfigParser(defaults)
+
+    cfg = configparser.ConfigParser()
+
+    # We make all key lookups case-sensitive to avoid aliasing of
+    # case-sensitive environment variables.
+    cfg.optionxform = lambda optionstr: optionstr
+
+    default_section = cfg.defaults()
+    for key, value in defaults.items():
+        default_section[key] = value
+
     return cfg
 
 
@@ -1294,7 +1304,7 @@ class Test(object):
         for (key, val) in addl.items():
             # Convert val to string since otherwise os.environ (and our clone)
             # trigger a TypeError upon insertion, and the caller may be unaware.
-            env[key.upper()] = str(val)
+            env[key] = str(val)
 
         for idx, key in enumerate(sorted(self.ports)):
             env[key] = str(self.bound_ports[idx]) + "/tcp"
@@ -2681,7 +2691,7 @@ if Options.update_times and not Timer:
 if Config.has_section("environment"):
     for (name, value) in Config.itemsNoDefaults("environment"):
         # Here we don't want to include items from defaults
-        os.environ[name.upper()] = value
+        os.environ[name] = value
 
 Alternatives = {}
 

--- a/testing/tests/env-var-casing.test
+++ b/testing/tests/env-var-casing.test
@@ -1,0 +1,16 @@
+# %TEST-DOC: Validates that env vars are case-sensitive; this is a regression test for #75.
+#
+# %TEST-EXEC: http_proxy=aaa HTTP_PROXY=bbb btest -dv test
+
+# %TEST-START-FILE btest.cfg
+[environment]
+http_PROXY=ccc
+Http_Proxy=ddd
+# %TEST-END-FILE
+
+# %TEST-START-FILE test
+# @TEST-EXEC: env | grep http_proxy=aaa
+# @TEST-EXEC: env | grep HTTP_PROXY=bbb
+# @TEST-EXEC: env | grep http_PROXY=ccc
+# @TEST-EXEC: env | grep Http_Proxy=ddd
+# %TEST-END-FILE

--- a/testing/tests/versioning.test
+++ b/testing/tests/versioning.test
@@ -8,5 +8,5 @@
 %TEST-START-FILE btest.cfg
 [btest]
 TmpDir      = .tmp
-Minversion  = 99999.99
+MinVersion  = 99999.99
 %TEST-END-FILE


### PR DESCRIPTION
Options in our ini file are usually interpreted as environment variables which are case-sensitive on many platforms, e.g., `http_proxy` and `HTTP_PROXY` are different environment variables. Our config parser reads in environment variables as configuration value defaults, but the `ConfigParser` used under the covers prefers to treat them as case-insensitve in its default ini file dialect.

With this patch we now override this behavior of our config parser and treat config keys as case-sensitive. This yields the expected behavior for environment variables, but also is a API-breaking change for our ini files where we preserve case as well.

Closes #75.