### PR TITLE
Better protection against garbled output with parallelized tests

### DIFF
--- a/btest
+++ b/btest
@@ -1571,7 +1571,7 @@ class OutputHandler:
         """Called just before a test begins."""
 
     def testCommand(self, test, cmdline):
-        """Called just before a command line is exected for a trace."""
+        """Called just before a command line is executed for a trace."""
 
     def testProgress(self, test, msg):
         """Called when a test signals having made progress."""
@@ -1621,7 +1621,7 @@ class Forwarder(OutputHandler):
             h.testStart(test)
 
     def testCommand(self, test, cmdline):
-        """Called just before a command line is exected for a trace."""
+        """Called just before a command line is executed for a trace."""
         for h in self._handlers:
             h.testCommand(test, cmdline)
 
@@ -1663,6 +1663,12 @@ class Forwarder(OutputHandler):
 
 
 class Standard(OutputHandler):
+    """
+    The default output handler, writing plain lines with test outcome.
+
+    Each test result is reported. For parallelized operation, the output
+    includes the thread number processing the test.
+    """
     def testStart(self, test):
         self.output(test, self.threadPrefix(), nl=False)
         self.output(test, "%s ..." % test.displayName(), nl=False)

--- a/btest
+++ b/btest
@@ -1727,9 +1727,8 @@ class Console(OutputHandler):
     Normal = "\033[0m"
 
     def __init__(self, options):
-        OutputHandler.__init__(self, options)
+        OutputHandler.__init__(self, options, reopen_std_file(sys.__stdout__))
         self.show_all = True
-        self.stdout = reopen_std_file(sys.__stdout__)
 
     def testStart(self, test):
         msg = "[%3d%%] %s ..." % (test.mgr.percentage(), test.displayName())
@@ -1765,18 +1764,18 @@ class Console(OutputHandler):
         self._consoleOutput(test, msg, self.show_all)
 
     def finished(self):
-        self.stdout.flush()
+        self._outfile.flush()
 
     def _consoleOutput(self, test, msg, sticky):
         self._consoleWrite(test, msg, sticky)
 
     def _consoleWrite(self, test, msg, sticky):
-        self.stdout.write(msg.strip() + " ")
+        self._outfile.write(msg.strip() + " ")
 
         if sticky:
-            self.stdout.write("\n")
+            self._outfile.write("\n")
 
-        self.stdout.flush()
+        self._outfile.flush()
 
 
 class CompactConsole(Console):
@@ -1795,17 +1794,16 @@ class CompactConsole(Console):
     def __init__(self, options):
         Console.__init__(self, options)
         self.show_all = False
-        self.stdout = reopen_std_file(sys.__stdout__)
 
         def cleanup():
-            self.stdout.write(self.CursorOn)
+            self._outfile.write(self.CursorOn)
 
         atexit.register(cleanup)
 
     def testStart(self, test):
         test.console_last_line = None
         self._consoleOutput(test, "", False)
-        self.stdout.write(self.CursorOff)
+        self._outfile.write(self.CursorOff)
 
     def testProgress(self, test, msg):
         """Called when a test signals having made progress."""
@@ -1816,10 +1814,10 @@ class CompactConsole(Console):
         test.console_last_line = None
 
     def finished(self):
-        self.stdout.write(self.EraseToEndOfLine)
-        self.stdout.write("\r")
-        self.stdout.write(self.CursorOn)
-        self.stdout.flush()
+        self._outfile.write(self.EraseToEndOfLine)
+        self._outfile.write("\r")
+        self._outfile.write(self.CursorOn)
+        self._outfile.flush()
 
     def _consoleOutput(self, test, msg, sticky):
         line = "[%3d%%] %s ..." % (test.mgr.percentage(), test.displayName())
@@ -1831,20 +1829,20 @@ class CompactConsole(Console):
         self._consoleWrite(test, line, sticky)
 
     def _consoleAugment(self, test, msg):
-        self.stdout.write(self.EraseToEndOfLine)
-        self.stdout.write(" %s" % msg.strip())
-        self.stdout.write("\r%s" % test.console_last_line)
-        self.stdout.flush()
+        self._outfile.write(self.EraseToEndOfLine)
+        self._outfile.write(" %s" % msg.strip())
+        self._outfile.write("\r%s" % test.console_last_line)
+        self._outfile.flush()
 
     def _consoleWrite(self, test, msg, sticky):
-        self.stdout.write(chr(27) + '[2K')
-        self.stdout.write("\r%s" % msg.strip())
+        self._outfile.write(chr(27) + '[2K')
+        self._outfile.write("\r%s" % msg.strip())
 
         if sticky:
-            self.stdout.write("\n")
+            self._outfile.write("\n")
             test.console_last_line = None
 
-        self.stdout.flush()
+        self._outfile.flush()
 
 
 class Brief(OutputHandler):

--- a/btest
+++ b/btest
@@ -1496,7 +1496,7 @@ class Test(object):
 
 
 class OutputHandler:
-    def __init__(self, options):
+    def __init__(self, options, outfile=sys.__stderr__):
         """Base class for reporting progress and results to user. We derive
         several classes from this one, with the one being used depending on
         which output the users wants.
@@ -1507,9 +1507,12 @@ class OutputHandler:
         concurrently.
 
         options: An optparser with the global options.
+
+        outfile: The destination file object to write output to.
         """
         self._buffered_output = {}
         self._options = options
+        self._outfile = outfile
 
     def prepare(self, mgr):
         """The TestManager calls this with itself as an argument just before
@@ -1531,7 +1534,7 @@ class OutputHandler:
 
     def _output(self, msg, nl=True, file=None):
         if not file:
-            file = reopen_std_file(sys.__stderr__)
+            file = reopen_std_file(self._outfile)
 
         if nl:
             print(msg, file=file)

--- a/btest
+++ b/btest
@@ -1528,7 +1528,11 @@ class OutputHandler:
         a form suitable to prefix output with. With a single thread, returns
         the empty string."""
         if self.options().threads > 1:
-            return "[%s]" % mp.current_process().name
+            # TestManager.run() defines the process names to "#<n>".  Align the
+            # prefixes by using enough space for the number of threads
+            # requested, plus 1 for "#".
+            pat = "[%%+%ds]" % (len(str(self.options().threads)) + 1)
+            return pat % mp.current_process().name
         else:
             return ""
 

--- a/btest
+++ b/btest
@@ -1711,7 +1711,7 @@ class Standard(OutputHandler):
 
 class Console(OutputHandler):
     """
-    Output handler that writes colorful progress report to the console.
+    Output handler that writes colorful progress report to stdout.
 
     This handler works well in settings that can handle coloring but not
     cursor placement commands (for example because moving to the beginning of
@@ -1728,16 +1728,15 @@ class Console(OutputHandler):
 
     def __init__(self, options):
         OutputHandler.__init__(self, options, reopen_std_file(sys.__stdout__))
-        self.show_all = True
 
     def testStart(self, test):
         msg = "[%3d%%] %s ..." % (test.mgr.percentage(), test.displayName())
-        self._consoleOutput(test, msg, False)
+        self.output(test, msg, nl=False)
 
     def testProgress(self, test, msg):
         """Called when a test signals having made progress."""
         msg = self.DarkGray + "(%s)" % msg + self.Normal
-        self._consoleOutput(test, msg, True)
+        self.output(test, msg)
 
     def testSucceeded(self, test, msg):
         if test.known_failure:
@@ -1745,7 +1744,7 @@ class Console(OutputHandler):
         else:
             msg = self.Green + msg + self.Normal
 
-        self._consoleOutput(test, msg, self.show_all)
+        self.output(test, msg)
 
     def testFailed(self, test, msg):
         if test.known_failure:
@@ -1753,35 +1752,21 @@ class Console(OutputHandler):
         else:
             msg = self.Red + msg + self.Normal
 
-        self._consoleOutput(test, msg, True)
+        self.output(test, msg)
 
     def testUnstable(self, test, msg):
         msg = self.Yellow + msg + self.Normal
-        self._consoleOutput(test, msg, True)
+        self.output(test, msg)
 
     def testSkipped(self, test, msg):
         msg = self.Gray + msg + self.Normal
-        self._consoleOutput(test, msg, self.show_all)
-
-    def finished(self):
-        self._outfile.flush()
-
-    def _consoleOutput(self, test, msg, sticky):
-        self._consoleWrite(test, msg, sticky)
-
-    def _consoleWrite(self, test, msg, sticky):
-        self._outfile.write(msg.strip() + " ")
-
-        if sticky:
-            self._outfile.write("\n")
-
-        self._outfile.flush()
+        self.output(test, msg)
 
 
 class CompactConsole(Console):
     """
     Output handler that writes compact, colorful progress report to
-    the console while also keeping the output compact by keeping
+    stdout while also keeping the output compact by keeping
     output only for failing tests.
 
     This handler adds cursor mods and navigation to the coloring provided by
@@ -1793,7 +1778,6 @@ class CompactConsole(Console):
 
     def __init__(self, options):
         Console.__init__(self, options)
-        self.show_all = False
 
         def cleanup():
             self._outfile.write(self.CursorOn)
@@ -1810,8 +1794,32 @@ class CompactConsole(Console):
         msg = " " + self.DarkGray + "(%s)" % msg + self.Normal
         self._consoleAugment(test, msg)
 
+    def testSucceeded(self, test, msg):
+        if test.known_failure:
+            msg = self.Yellow + msg + self.Normal
+        else:
+            msg = self.Green + msg + self.Normal
+
+        self._consoleOutput(test, msg, False)
+
+    def testFailed(self, test, msg):
+        if test.known_failure:
+            msg = self.Yellow + msg + self.Normal
+        else:
+            msg = self.Red + msg + self.Normal
+
+        self._consoleOutput(test, msg, True)
+
     def testFinished(self, test, msg):
         test.console_last_line = None
+
+    def testUnstable(self, test, msg):
+        msg = self.Yellow + msg + self.Normal
+        self._consoleOutput(test, msg, True)
+
+    def testSkipped(self, test, msg):
+        msg = self.Gray + msg + self.Normal
+        self._consoleOutput(test, msg, False)
 
     def finished(self):
         self._outfile.write(self.EraseToEndOfLine)

--- a/testing/Scripts/script-command
+++ b/testing/Scripts/script-command
@@ -1,10 +1,14 @@
-# This is a wrapper for the "script" command, which has different
-# options depending on the OS.
+# This is a wrapper for the "script" command, which has different options
+# depending on the OS. "script" can have side-effects on the current terminal
+# when invoked, breaking some carriage returns. Closing its stdin seems to
+# prevent that.
 
-if ! script -q -c ls /dev/null >/dev/null 2>&1; then
-    # FreeBSD and macOS
-    script -q /dev/null $@
-else
-    # Linux
-    script -qfc "$@" /dev/null
-fi
+true | {
+    if ! script -q -c ls /dev/null >/dev/null 2>&1; then
+        # FreeBSD and macOS
+        script -q /dev/null $@
+    else
+        # Linux
+        script -qfc "$@" /dev/null
+    fi
+}


### PR DESCRIPTION
I've encountered two separate sources of garbled output with btest. The former happened only on its own testsuite when running without a TTY, looking like this:
```
$ cd testing
$ ../btest -j | cat
[#12] tests.alternatives-undefined ... ok
[#7] tests.alternatives-overwrite-env ... ok
[#9] tests.alternatives-reread-config ... ok
[#11] tests.alternatives-testbase ... ok
[#1] tests.abort-on-failure ... ok
[#8] tests.alternatives-reread-config-baselinedir ... ok
[#15] tests.basic-succeed ... ok
[#13] tests.basic-fail ... ok
                             [#2] tests.abort-on-failure-with-only-known-fails ... ok
                                                                                     [#2] tests.crlf-line-terminators ... ok
                                                                                                                            [#5] tests.alternatives-filter ... ok
                                                                                                                                                                 [#9] tests.canonifier ... ok
                                                                                                                                                                                             [#10] tests.alternatives-substitution ... ok
                                       [#11] tests.canonifier-cmdline ... ok
                                                                            [#8] tests.canonifier-fail ... ok
                                                                                                             [#3] tests.alternatives-baseline-dir ... ok
                                                                                                                                                        [#13] tests.copy-file ... ok
                                                                                                                                                                                    [#14] tests.baseline-dir-env ... ok
                     [#5] tests.diag-all ... ok
                                               [#9] tests.diag-file ... ok
                                                                          [#12] tests.brief ... ok
                                                                                                  [#11] tests.diff-brief ... ok
                                                                                                                               [#9] tests.environment-windows ... not available, skipped
                                                                                                                                                                                        [#6] tests.alternatives-keywords ... ok
                             [#3] tests.doc ... ok
[#16] tests.binary-mode ... ok
[#13] tests.duplicate-selection ... ok
[#15] tests.console ... ok
[#2] tests.diag ... ok
```
Turns out this was due to `console.test`, via a side-effect introduced by `script`.

The other source of garbling was as reported by Benjamin in #70, which this also addresses.

Resolves #70.