### PR TITLE
Alpine fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 dist
 MANIFEST
 .idea
+sphinx/btest.egg-info/

--- a/btest-diff
+++ b/btest-diff
@@ -225,7 +225,10 @@ if [ -n "$baseline" ]; then
         if is_binary_mode; then
             diff -s "$@" "$canon_baseline" "$canon_output" >>$TEST_DIAGNOSTICS
         else
-            diff -au --strip-trailing-cr "$@" "$canon_baseline" "$canon_output" >>$TEST_DIAGNOSTICS
+            # We'd use --strip-trailing-cr in the following, but it's not guaranteed.
+            diff -au "$@" \
+                <(sed 's/\r$//' "$canon_baseline") \
+                <(sed 's/\r$//' "$canon_output") >>$TEST_DIAGNOSTICS
         fi
         result=$?
     fi

--- a/btest-progress
+++ b/btest-progress
@@ -11,6 +11,20 @@ EOF
     exit 1
 }
 
+function get_date {
+    # Some date versions don't provide nanosecond substitution, yielding various
+    # strings instead ("." on Alpine, ".3NZ" on FreeBSD). Check if we got three
+    # digits and a "Z", otherwise fake the nanoseconds.
+    local res
+    res=$(date -u +'%Y-%m-%dT%H:%M:%S.%3NZ')
+
+    if echo "$res" | grep -q '[0-9][0-9][0-9]Z$'; then
+        echo "$res"
+    else
+        date -u +'%Y-%m-%dT%H:%M:%S.000Z'
+    fi
+}
+
 ### Main.
 
 quiet=0
@@ -41,7 +55,7 @@ if [ "${quiet}" -eq 0 ]; then
     if [ "${time}" -eq 0 ]; then
         echo "${msg}" >&2
     else
-        echo "${msg} -- $(date -u +'%Y-%m-%dT%H:%M:%S.%3NZ') " >&2
+        echo "${msg} -- $(get_date) " >&2
     fi
 fi
 


### PR DESCRIPTION
While working on #92 I noticed that two tests were broken when running on Alpine, so this fixes both. Would be good to get confirmation that the `btest-diff` tweak actually looks as expected on Windows, but I think that's covered by the testsuite.

Resolves #92.