### PR TITLE
CI: automatically push to PyPI when pushing a git tag

### DIFF
--- a/.github/workflows/btest.yml
+++ b/.github/workflows/btest.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: [master]
+    tags:
+      - 'v*'
+      - '!v*-dev'
 
 jobs:
   Run-BTest:
@@ -73,3 +76,28 @@ jobs:
       - name: "Test building package"
         run: |
             python3 setup.py sdist bdist_wheel
+
+  Upload:
+    runs-on: ubuntu-latest
+    needs: [Run-BTest, Test-SetupPY]
+    if: github.repository == 'zeek/btest' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check release version
+        # This fails e.g. if VERSION contains a dev commits suffix,
+        # since we don't want to push these to PyPI. Accepts two-
+        # and three-component version numbers (e.g. 1.0 and 1.0.1).
+        run: |
+          grep -E -x '[0-9]+\.[0-9]+(\.[0-9]+)?' VERSION
+      - name: Build sdist
+        # This places the sdist in the build folder, so we need to
+        # tell the action below where to find it since it defaults
+        # to dist/.
+        run: |
+          make dist
+      - name: Upload to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: build/
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This already works over in the `zeek-client` repo, so I'd like to bring it to more of our Python projects. The only difference is that we're using 2- and 3-part version numbers here in btest, so I've tweaked the grep regex for it.

I've tested it over in my fork (with an intentional fail in the actual PyPI push to their test repo), see [here](https://github.com/ckreibich/btest/actions/runs/5427593583).