### PR TITLE
Simplify generation of temporary files

### DIFF
--- a/btest-diff
+++ b/btest-diff
@@ -186,7 +186,7 @@ if [ -z "$TEST_DIFF_CANONIFIER" ] || is_binary_mode; then
     TEST_DIFF_CANONIFIER="cat"
 fi
 
-canon_output=/tmp/test-diff.$$.$canon.tmp
+canon_output=$(mktemp -t "test-diff.$canon.tmp.XXXXXX")
 tmpfiles="$tmpfiles $canon_output"
 error=0
 
@@ -201,7 +201,7 @@ if [ $? -ne 0 ]; then
 fi
 
 if [ -n "$baseline" ]; then
-    canon_baseline=/tmp/test-diff.$$.$canon.baseline.tmp
+    canon_baseline=$(mktemp -t "test-diff.$canon.baseline.tmp.XXXXXX")
     tmpfiles="$tmpfiles $canon_baseline"
 
     # Prepare the baseline. When created by a recent btest-diff, we


### PR DESCRIPTION
Instead of manuall relying in `$$` being unique, with this patch we instead use `mktemp` which creates a unique, temporary file which we can use later. This also removes the possibility that we accidentially overwrite other existing files in the final location, e.g., from previous, failed runs.

Via the default behavior of `mktemp` with this patch we also switch from forced generation of temporary files in `/tmp` to possibly `$TMPDIR` if set.