### PR TITLE
Standardize on ruff for python formatting/linting via pre-commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,20 +22,17 @@ repos:
   - id: end-of-file-fixer
     exclude: ^testing/Baseline|examples/.*Baseline.*
 
-- repo: https://github.com/psf/black
-  rev: 23.7.0
-  hooks:
-  - id: black
-
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.10.1
+  rev: v3.15.1
   hooks:
   - id: pyupgrade
     args: ["--py37-plus"]
 
-- repo: https://github.com/pycqa/flake8
-  rev: 6.1.0  # 6.0.0 requires Python 3.8
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.3.0
   hooks:
-  - id: flake8
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format
 
 exclude: examples/sphinx/conf.py


### PR DESCRIPTION
This is part of a minor effort to standardize all of our python pre-commits on the same tooling, in this case [ruff](https://github.com/astral-sh/ruff).