### PR TITLE
btest-bg-run-helper: Ignore SIGTERM to self during cleanup

### DIFF
--- a/btest-bg-run-helper
+++ b/btest-bg-run-helper
@@ -3,8 +3,19 @@
 # Internal helper for btest-bg-run.
 
 cleanup() {
+    # Ignore SIGTERM during cleanup to prevent terminating
+    # this process when sending signals to the process group.
+    trap true SIGTERM
+
     if [ ! -e .exitcode ]; then
         echo 15 >.exitcode
+
+        # Send SIGTERM to all processes in the process group
+        # of the calling process.
+        #
+        # This should terminate any well-behaved background
+        # commands that were spawned by the program under test
+        # unless they started their own process group.
         kill 0 &>/dev/null
 
         if [ -n "$pid" ]; then

--- a/btest-setsid
+++ b/btest-setsid
@@ -5,8 +5,9 @@ import sys
 
 try:
     os.setsid()
-except Exception:
-    pass
+except Exception as e:
+    print(f"btest-setsid failed: {e!r}", file=sys.stderr)
+    exit(1)
 
 prog = sys.argv[1]
 args = sys.argv[1:]


### PR DESCRIPTION
The kill 0 invocation would kill the btest-bg-run-helper itself, causing the subsequent logic to not be executed, resulting in runaway processes on the system.