### PR TITLE
Require CMake 3.15, inline with other Zeek projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15.0 FATAL_ERROR)
 project(btest)
 
 # Install scripts


### PR DESCRIPTION
I'm not sure why this wasn't changed when we changed all of the other ones way back when, but here we are.