### PR TITLE
Automatically cancel exisiting GH CI workflows on PR update

### DIFF
--- a/.github/workflows/btest.yml
+++ b/.github/workflows/btest.yml
@@ -8,6 +8,10 @@ on:
       - 'v*'
       - '!v*-dev'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   Run-BTest:
     strategy:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Similar to https://github.com/zeek/zeek/pull/5531