### PR TITLE
Prevent progress printing `100%` if not fully done

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,20 +2,20 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.10.0.1
+  rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
   hooks:
   - id: shellcheck
     exclude: examples/|testing/tests/.*\.sh
 
 - repo: https://github.com/maxwinterstein/shfmt-py
-  rev: v3.11.0.2
+  rev: 85cc16bc0319e182d7b62b0a2de351358083ce4c  # frozen: v4.0.0
   hooks:
   - id: shfmt
     exclude: examples/t6.sh
     args: ["-w", "-i", "4", "-ci"]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # frozen: v6.0.0
   hooks:
   - id: trailing-whitespace
     exclude: ^testing/Baseline
@@ -23,7 +23,7 @@ repos:
     exclude: ^testing/Baseline|examples/.*Baseline.*
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.6
+  rev: 77039ccbba72c8aede339c5f8ae29b42aced0a2e  # frozen: v0.15.18
   hooks:
     - id: ruff
       args: [--fix]

--- a/btest
+++ b/btest
@@ -1832,7 +1832,7 @@ class Console(OutputHandler):
         OutputHandler.__init__(self, options, reopen_std_file(sys.__stdout__))
 
     def testStart(self, test):
-        msg = f"[{test.mgr.percentage():>3.0f}%] {test.displayName()} ..."
+        msg = f"[{int(test.mgr.percentage()):>3d}%] {test.displayName()} ..."
         self.output(test, msg, nl=False)
 
     def testProgress(self, test, msg):
@@ -1931,7 +1931,7 @@ class CompactConsole(Console):
         self._outfile.flush()
 
     def _consoleOutput(self, test, msg, sticky):
-        line = f"[{test.mgr.percentage():>3.0f}%] {test.displayName()} ..."
+        line = f"[{int(test.mgr.percentage()):>3d}%] {test.displayName()} ..."
 
         if msg:
             line += " " + msg

--- a/btest-diff
+++ b/btest-diff
@@ -148,12 +148,7 @@ if [ ! -f "$input" ]; then
 fi
 
 tmpfiles=""
-delete_tmps() {
-    # shellcheck disable=SC2086,SC2317
-    rm -f $tmpfiles 2>/dev/null
-}
-
-trap delete_tmps 0
+trap 'rm -f $tmpfiles 2>/dev/null' 0
 
 # First available baseline across directories.
 baseline=""

--- a/sphinx/btest-sphinx.py
+++ b/sphinx/btest-sphinx.py
@@ -6,7 +6,6 @@ import subprocess
 from docutils import nodes, utils
 from docutils.parsers.rst import Directive, Parser, directives
 from docutils.transforms import Transform
-
 from sphinx.directives.code import LiteralInclude
 from sphinx.errors import SphinxError
 from sphinx.util import logging


### PR DESCRIPTION
Previously we could print a test progress of `100%` even though there
were still tests running due to how we might round up, and for projects
with huge BTest suite this was pretty likely. With this patch we make
sure we _always_ round down to the nearest integer so we don't report
"all done" before we are actually done.